### PR TITLE
add tests and simplify some of the API methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Test
 test:
-	go test -timeout 3600s -parallel $(shell nproc) ./...
+	go test -timeout 3600s -parallel $(shell nproc) -race ./...
 
 # Benchmark
 benchmark:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/loopholelabs/goroutine-manager
 
 go 1.22.5
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/manager/goroutine.go
+++ b/pkg/manager/goroutine.go
@@ -12,22 +12,25 @@ type GoroutineManagerHooks struct {
 	OnAfterRecover func() // Runs after recovering from a panic, but before stopping all goroutines
 }
 
-// GoroutineManager
+// GoroutineManager provides panic handling and lifecycle management for
+// goroutines.
 type GoroutineManager struct {
+	errs     *error
 	errsLock *sync.Mutex
 	wg       *sync.WaitGroup
 
-	goroutineCtx      context.Context
+	internalCtx       context.Context
 	cancelInternalCtx context.CancelCauseFunc
 
 	errFinished error
 
-	recoverFromPanics func(track bool) func()
-
-	errGoroutineStopped error
+	hooks GoroutineManagerHooks
 }
 
-// NewGoroutineManager creates a new goroutine manager
+// NewGoroutineManager creates a new goroutine manager.
+//
+// Errors caused by panics are stored in errs, which must only be accessed
+// after Wait() returns.
 func NewGoroutineManager(
 	ctx context.Context, // Parent context to use
 
@@ -44,37 +47,8 @@ func NewGoroutineManager(
 
 	errFinished := errors.New("finished") // This has to be a distinct error type for each panic handler, so we can't define it on the package level
 
-	recoverFromPanics := func(track bool) func() {
-		return func() {
-			if track {
-				defer wg.Done()
-			}
-
-			if err := recover(); err != nil {
-				errsLock.Lock()
-				defer errsLock.Unlock()
-
-				var e error
-				if v, ok := err.(error); ok {
-					e = v
-				} else {
-					e = fmt.Errorf("%v", err)
-				}
-
-				if !(errors.Is(e, context.Canceled) && errors.Is(context.Cause(internalCtx), errFinished)) {
-					*errs = errors.Join(*errs, e)
-
-					if hook := hooks.OnAfterRecover; hook != nil {
-						hook()
-					}
-				}
-
-				cancelInternalCtx(errFinished)
-			}
-		}
-	}
-
 	return &GoroutineManager{
+		errs,
 		&errsLock,
 		&wg,
 
@@ -83,9 +57,7 @@ func NewGoroutineManager(
 
 		errFinished,
 
-		recoverFromPanics,
-
-		errFinished,
+		hooks,
 	}
 }
 
@@ -101,42 +73,79 @@ func (m *GoroutineManager) CreateBackgroundPanicCollector() func() {
 	return m.recoverFromPanics(false)
 }
 
-// Starts a goroutine that can't be waited for to finish and associates a panic collector
-func (m *GoroutineManager) StartForegroundGoroutine(fn func()) {
+// Starts a goroutine that can be waited for to finish and associates a panic collector
+func (m *GoroutineManager) StartForegroundGoroutine(fn func(context.Context)) {
 	m.wg.Add(1)
 
 	go func() {
 		defer m.recoverFromPanics(true)()
 
-		fn()
+		fn(m.internalCtx)
 	}()
 }
 
 // Starts a goroutine that can't be waited for to finish and associates a panic collector
-func (m *GoroutineManager) StartBackgroundGoroutine(fn func()) {
+func (m *GoroutineManager) StartBackgroundGoroutine(fn func(context.Context)) {
 	go func() {
 		defer m.recoverFromPanics(false)()
 
-		fn()
+		fn(m.internalCtx)
 	}()
 }
 
-// Stops both foreground and background goroutines by cancelling the goroutine context, but doesn't wait for them to finish
+// Stops both foreground and background goroutines by cancelling the goroutine
+// context, but doesn't wait for them to finish.
+//
+// Since the goroutine context is cancelled, goroutines started after
+// StopAllGoroutines() is called may return immediately.
 func (m *GoroutineManager) StopAllGoroutines() {
 	m.cancelInternalCtx(m.errFinished)
 }
 
-// Waits for all foreground goroutines to finish
-func (m *GoroutineManager) WaitForForegroundGoroutines() {
+// Waits for all foreground goroutines to finish. All calls must return before
+// starting new foreground goroutines.
+func (m *GoroutineManager) Wait() {
 	m.wg.Wait()
 }
 
 // Gets the goroutine context that should be passed to any child goroutines
-func (m *GoroutineManager) GetGoroutineCtx() context.Context {
-	return m.goroutineCtx
+func (m *GoroutineManager) Context() context.Context {
+	return m.internalCtx
 }
 
 // Gets the context cause that is set when a goroutine is stopped by m.StopAllGoroutines()
 func (m *GoroutineManager) GetErrGoroutineStopped() error {
-	return m.errGoroutineStopped
+	return m.errFinished
+}
+
+// recoverFromPanics recovers the last panic and adds the error to errors list.
+// It musT be called from a defer statement, otherwise recover() returns nil.
+func (m *GoroutineManager) recoverFromPanics(track bool) func() {
+	return func() {
+		if track {
+			defer m.wg.Done()
+		}
+
+		if err := recover(); err != nil {
+			m.errsLock.Lock()
+			defer m.errsLock.Unlock()
+
+			var e error
+			if v, ok := err.(error); ok {
+				e = v
+			} else {
+				e = fmt.Errorf("%v", err)
+			}
+
+			if !(errors.Is(e, context.Canceled) && errors.Is(context.Cause(m.internalCtx), m.errFinished)) {
+				*m.errs = errors.Join(*m.errs, e)
+
+				if hook := m.hooks.OnAfterRecover; hook != nil {
+					hook()
+				}
+			}
+
+			m.cancelInternalCtx(m.errFinished)
+		}
+	}
 }

--- a/pkg/manager/goroutine_test.go
+++ b/pkg/manager/goroutine_test.go
@@ -1,0 +1,416 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testErr = errors.New("test error")
+
+func TestForegroundPanicRecover(t *testing.T) {
+	t.Parallel()
+
+	testFn := func(t *testing.T) (errs error) {
+		t.Helper()
+
+		m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{})
+
+		// Verification function needs to be registered before the panic and
+		// recovery so it runs after them.
+		defer func() {
+			require.ErrorIs(t, errs, testErr)
+			requireNotBlocked(t, m)
+			requireDone(t, m)
+		}()
+		defer m.Wait()
+		defer m.StopAllGoroutines()
+		defer m.CreateForegroundPanicCollector()()
+
+		panic(testErr)
+	}
+	err := testFn(t)
+	require.ErrorIs(t, err, testErr)
+}
+
+func TestBackgroundPanicRecover(t *testing.T) {
+	t.Parallel()
+
+	testFn := func(t *testing.T) (errs error) {
+		t.Helper()
+
+		m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{})
+
+		// Verification function needs to be registered before the panic and
+		// recovery so it runs after them.
+		defer func() {
+			require.ErrorIs(t, errs, testErr)
+			requireNotBlocked(t, m)
+			requireDone(t, m)
+		}()
+		defer m.Wait()
+		defer m.StopAllGoroutines()
+		defer m.CreateBackgroundPanicCollector()()
+
+		panic(testErr)
+	}
+	err := testFn(t)
+	require.ErrorIs(t, err, testErr)
+}
+
+func TestForegroundGoroutine(t *testing.T) {
+	t.Parallel()
+
+	var errs error
+	m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{})
+
+	done := make(chan any)
+	m.StartForegroundGoroutine(func(_ context.Context) {
+		<-done
+		panic(testErr)
+	})
+
+	// Verify goroutine manager is blocked and no error is set yet.
+	requireBlocked(t, m)
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+
+	// Unblock goroutine to cause the panic.
+	close(done)
+
+	// Verify goroutine manager unblocks and the panic error is set.
+	requireNotBlocked(t, m)
+	requireDone(t, m)
+	require.ErrorIs(t, errs, testErr)
+}
+
+func TestBackgroundGoroutine(t *testing.T) {
+	t.Parallel()
+
+	var errs error
+	m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{})
+
+	done := make(chan any)
+	m.StartBackgroundGoroutine(func(_ context.Context) {
+		<-done
+		panic(testErr)
+	})
+
+	// Verify goroutine manager is not blocked by background goroutines.
+	requireNotBlocked(t, m)
+
+	// Verify goroutine manager context is not cancelled and no error is set.
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+
+	// Unblock goroutine to cause the panic.
+	close(done)
+
+	// Verify goroutine manager is still not blocked, but its context is not
+	// done and the panic error is set.
+	requireNotBlocked(t, m)
+	requireDone(t, m)
+	require.ErrorIs(t, errs, testErr)
+}
+
+func TestStopAllGoroutines(t *testing.T) {
+	t.Parallel()
+
+	var errs error
+	m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{})
+
+	bgStarted := make(chan any)
+	bgDone := make(chan any)
+	m.StartBackgroundGoroutine(func(ctx context.Context) {
+		close(bgStarted)
+		<-ctx.Done()
+		close(bgDone)
+	})
+
+	fgStarted := make(chan any)
+	fgDone := make(chan any)
+	m.StartForegroundGoroutine(func(ctx context.Context) {
+		close(fgStarted)
+		<-ctx.Done()
+		close(fgDone)
+	})
+
+	// Wait for goroutines to start.
+	<-bgStarted
+	<-fgStarted
+
+	// Verify goroutines are not done.
+	require.Never(t, func() bool {
+		<-bgDone
+		return true
+	}, 50*time.Millisecond, time.Millisecond)
+	require.Never(t, func() bool {
+		<-fgDone
+		return true
+	}, 50*time.Millisecond, time.Millisecond)
+
+	// Verify goroutine manager is blocked and no error is set.
+	requireBlocked(t, m)
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+
+	// Stop all goroutines.
+	m.StopAllGoroutines()
+	m.Wait()
+
+	// Verify goroutines are done.
+	<-bgDone
+	<-fgDone
+
+	// Verify goroutine manager is unblocked and no error is set because the
+	// goroutines didn't panic.
+	requireNotBlocked(t, m)
+	requireDone(t, m)
+	require.NoError(t, errs)
+}
+
+func TestMultipleGoroutines(t *testing.T) {
+	t.Parallel()
+
+	var errs error
+	m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{})
+
+	fg1 := make(chan any)
+	m.StartForegroundGoroutine(func(_ context.Context) {
+		<-fg1
+	})
+
+	fg2 := make(chan any)
+	go func() {
+		defer m.CreateForegroundPanicCollector()()
+		<-fg2
+	}()
+
+	bg1 := make(chan any)
+	m.StartBackgroundGoroutine(func(_ context.Context) {
+		<-bg1
+	})
+
+	// Verify goroutine manager is blocked and no error is set.
+	requireBlocked(t, m)
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+
+	// Unblock one foreground goroutine.
+	close(fg1)
+
+	// Verify goroutine manager is still blocked.
+	requireBlocked(t, m)
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+
+	// Unblock background goroutine.
+	close(bg1)
+
+	// Verify goroutine manager is still blocked.
+	requireBlocked(t, m)
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+
+	// Unblock second goroutine.
+	close(fg2)
+
+	// Verify goroutine manager is now unblocked, but context is still not done
+	// since there was no panic.
+	requireNotBlocked(t, m)
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+}
+
+func TestReuseGoroutineManager(t *testing.T) {
+	t.Parallel()
+
+	var errs error
+	m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{})
+
+	// Start a few goroutines and wait.
+	fg1 := make(chan any)
+	m.StartForegroundGoroutine(func(_ context.Context) {
+		<-fg1
+	})
+
+	fg2 := make(chan any)
+	m.StartForegroundGoroutine(func(_ context.Context) {
+		<-fg2
+	})
+
+	close(fg1)
+	close(fg2)
+	m.Wait()
+
+	// Start another set of goroutines and wait again.
+	fg3 := make(chan any)
+	m.StartForegroundGoroutine(func(_ context.Context) {
+		<-fg3
+	})
+
+	fg4 := make(chan any)
+	m.StartForegroundGoroutine(func(_ context.Context) {
+		<-fg4
+	})
+
+	close(fg3)
+	close(fg4)
+	m.Wait()
+
+	// Start more goroutines using the internal context and stop them.
+	m.StartForegroundGoroutine(func(ctx context.Context) {
+		<-ctx.Done()
+	})
+
+	m.StartForegroundGoroutine(func(ctx context.Context) {
+		<-ctx.Done()
+	})
+
+	m.StopAllGoroutines()
+	m.Wait()
+
+	// Verify goroutines started after stop return immediately.
+	done := false
+	m.StartForegroundGoroutine(func(ctx context.Context) {
+		select {
+		case <-ctx.Done():
+			done = true
+			return
+		default:
+		}
+		panic(testErr)
+	})
+	m.Wait()
+	require.True(t, done)
+	require.NoError(t, errs)
+}
+
+func TestMultipleGoroutineErrors(t *testing.T) {
+	t.Parallel()
+
+	var errs error
+	m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{})
+
+	err1 := errors.New("test error 1")
+	fg1 := make(chan any)
+	m.StartForegroundGoroutine(func(ctx context.Context) {
+		<-fg1
+		panic(err1)
+	})
+
+	err2 := errors.New("test error 2")
+	m.StartForegroundGoroutine(func(ctx context.Context) {
+		<-ctx.Done()
+		panic(err2)
+	})
+
+	// Verify goroutine manager is blocked and no error is set yet.
+	requireBlocked(t, m)
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+
+	// Unblock first goroutine to cause a panic.
+	close(fg1)
+
+	// Verify second goroutine and the goroutine manager were unblocked by the
+	// panic.
+	requireNotBlocked(t, m)
+
+	// Verify both panics were captured.
+	require.ErrorIs(t, errs, err2)
+	require.ErrorIs(t, errs, err1)
+}
+
+func TestParentContext(t *testing.T) {
+	t.Parallel()
+
+	var errs error
+	ctx, cancel := context.WithCancel(context.Background())
+	m := NewGoroutineManager(ctx, &errs, GoroutineManagerHooks{})
+
+	m.StartForegroundGoroutine(func(ctx context.Context) {
+		<-ctx.Done()
+		panic(testErr)
+	})
+
+	// Verify goroutine manager is blocked and no error is set yet.
+	requireBlocked(t, m)
+	requireNotDone(t, m)
+	require.NoError(t, errs)
+
+	// Cancel parent context.
+	cancel()
+
+	// Verify goroutine manager is unblocked and the panic error is set.
+	requireNotBlocked(t, m)
+	requireDone(t, m)
+	require.ErrorIs(t, errs, testErr)
+}
+
+func TestHooks_OnAfterRecover(t *testing.T) {
+	t.Parallel()
+
+	var counter atomic.Uint64
+	var errs error
+	m := NewGoroutineManager(context.Background(), &errs, GoroutineManagerHooks{
+		OnAfterRecover: func() {
+			counter.Add(1)
+		},
+	})
+
+	for i := 0; i < 300; i++ {
+		m.StartForegroundGoroutine(func(_ context.Context) {
+			panic(testErr)
+		})
+	}
+
+	m.Wait()
+	require.Equal(t, uint64(300), counter.Load())
+}
+
+// requireBlocked fails if the goroutine manager Wait() method is not blocked.
+func requireBlocked(t *testing.T, m *GoroutineManager) {
+	t.Helper()
+
+	require.Never(t, func() bool {
+		m.Wait()
+		return true
+	}, 100*time.Millisecond, time.Millisecond, "goroutine manager is not blocked")
+}
+
+// requireBlocked fails if the goroutine manager Wait() method is blocked.
+func requireNotBlocked(t *testing.T, m *GoroutineManager) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		m.Wait()
+		return true
+	}, 10*time.Millisecond, time.Millisecond, "goroutine manager is blocked")
+}
+
+// requireDone fails if the goroutine manager Context() is not done.
+func requireDone(t *testing.T, m *GoroutineManager) {
+	t.Helper()
+
+	select {
+	case <-m.Context().Done():
+	default:
+		t.Fatalf("expected goroutine context to not be done")
+	}
+}
+
+// requireDone fails if the goroutine manager Context() is done.
+func requireNotDone(t *testing.T, m *GoroutineManager) {
+	t.Helper()
+
+	select {
+	case <-m.Context().Done():
+		t.Fatalf("expected goroutine context to not be done")
+	default:
+	}
+}


### PR DESCRIPTION
Add some tests to verify the behaviour of the goroutine manager under different scenarios. Since there are some shared data across the goroutines started by the manager, the -race flag can be important to detect potential data races.

Additional improvements:

1. Move `recoverFromPanics()` to a struct method instead of a closure. The only variables from the closure being accessed were `errs` and `hooks`, so they were also added to the struct.
2. There were some inconsistency with the `goroutineCtx` and `cancelInternalCtx` fields, so rename `goroutineCtx` to `internalCtx`.
3. There were two errors in the struct `errFinished` and `errGoroutineStopped`. `errFinished` was being used in mostly everywhere, except `GetErrGoroutineStopped()`. This wasn't a problem because there were both set to the same value in `NewGoroutineManager()`, but only one seems to needed.
4. Pass the goroutine manager context to `StartForegroundGoroutine()` and `StartBackgroundGoroutine()` so it's easier to wait on the right context when creating goroutines. Without this, users need to remember to check the manager's context directly.
5. Simplify some of the method names.

   `WaitForForegroundGoroutines()` implies the existence of a way to wait on background goroutines (which doesn't exist), and it also waits for more than just goroutines (like foreground panic handlers). Calling it just `Wait()` is enough to describe its behaviour and it also matches some of the interfaces for other Go standard library structs.

   `GetGoroutineCtx()` was a little redundant, since there's only one context and the struct is already called `GoroutineManager`. Calling it just `Context()` removes the duplicate information and also matches some of Go's interfaces, like `request.Context()`.
6. Add some godoc notes about edge cases and data races. For example, trying to access `errs` while there are still goroutines running, or starting a foreground goroutine while a call to `Wait()` has not returned yet (this is an artifact of how `WaitGroup.Add()` works).